### PR TITLE
Add protocol registry token validations

### DIFF
--- a/pkg/operation.go
+++ b/pkg/operation.go
@@ -60,12 +60,15 @@ func (gpo *GenericProtocolOperation) Validate(asset common.Address) error {
 	}
 
 	if len(addrs) == 0 {
-		return nil
+		if strings.ToLower(asset.Hex()) == nativeDenomAddress {
+			return nil
+		}
+
+		return fmt.Errorf("unsupported asset for %s ( %s )", gpo.Protocol, asset)
 	}
 
 	for _, addr := range addrs {
-		if strings.ToLower(asset.Hex()) == strings.ToLower(addr) ||
-			strings.ToLower(asset.Hex()) == nativeDenomAddress {
+		if strings.ToLower(asset.Hex()) == strings.ToLower(addr) {
 			return nil
 		}
 	}

--- a/pkg/operation.go
+++ b/pkg/operation.go
@@ -68,7 +68,7 @@ func (gpo *GenericProtocolOperation) Validate(asset common.Address) error {
 	}
 
 	for _, addr := range addrs {
-		if strings.ToLower(asset.Hex()) == strings.ToLower(addr) {
+		if strings.EqualFold(strings.ToLower(asset.Hex()), strings.ToLower(addr)) {
 			return nil
 		}
 	}

--- a/pkg/operation.go
+++ b/pkg/operation.go
@@ -60,7 +60,7 @@ func (gpo *GenericProtocolOperation) Validate(asset common.Address) error {
 	}
 
 	if len(addrs) == 0 {
-		if strings.ToLower(asset.Hex()) == nativeDenomAddress {
+		if strings.EqualFold(strings.ToLower(asset.Hex()), nativeDenomAddress) {
 			return nil
 		}
 

--- a/pkg/operation.go
+++ b/pkg/operation.go
@@ -3,8 +3,10 @@ package pkg
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -26,6 +28,11 @@ type ProtocolOperation interface {
 	// like Rocketpool and others. The current deposit pool address would need to be dynamically
 	// retrieved
 	GetContractAddress(ctx context.Context) (common.Address, error)
+
+	// Validate checks if the given asset is a valid one for this operation
+	// This will not be automatically called by GenerateCalldata.
+	// The client must call this to validate against the current known action type
+	Validate(asset common.Address) error
 }
 
 // GenericProtocolOperation provides a flexible implementation for generating calldata for any protocol operation.
@@ -37,6 +44,33 @@ type GenericProtocolOperation struct {
 func (gpo *GenericProtocolOperation) GetContractAddress(
 	_ context.Context) (common.Address, error) {
 	return gpo.Address, nil
+}
+
+// Validate checks if the given asset is a valid one for this operation
+func (gpo *GenericProtocolOperation) Validate(asset common.Address) error {
+
+	protocols, ok := tokenSupportedMap[gpo.ChainID.Int64()]
+	if !ok {
+		return errors.New("unsupported chain for asset validation")
+	}
+
+	addrs, ok := protocols[gpo.Protocol]
+	if !ok {
+		return errors.New("unsupported protocol for asset validation")
+	}
+
+	if len(addrs) == 0 {
+		return nil
+	}
+
+	for _, addr := range addrs {
+		if strings.ToLower(asset.Hex()) == strings.ToLower(addr) ||
+			strings.ToLower(asset.Hex()) == nativeDenomAddress {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unsupported asset for %s ( %s )", gpo.Protocol, asset)
 }
 
 // GenerateCalldata dynamically generates calldata for a contract method call based on the operation's ABI, method, and arguments.

--- a/pkg/registry_test.go
+++ b/pkg/registry_test.go
@@ -20,6 +20,43 @@ func getTestRPCURL(t *testing.T) string {
 	return u
 }
 
+func TestProtocolRegistry_Validate(t *testing.T) {
+	registry := NewProtocolRegistry()
+	SetupProtocolOperations(getTestRPCURL(t), registry)
+
+	t.Run("ValidateAave", func(t *testing.T) {
+		operation, err := registry.GetProtocolOperation(AaveV3, SupplyAction, big.NewInt(1))
+		require.NoError(t, err)
+
+		require.Nil(t, operation.Validate(common.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")))
+	})
+
+	t.Run("ValidateAave_UnsupportedAsset", func(t *testing.T) {
+		operation, err := registry.GetProtocolOperation(AaveV3, SupplyAction, big.NewInt(1))
+		require.NoError(t, err)
+
+		require.Error(t, operation.Validate(common.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb49")))
+	})
+
+	// t.Run("GetProtocolOperation_NotExists", func(t *testing.T) {
+	// 	operation, err := registry.GetProtocolOperation(AaveV3, SupplyAction, big.NewInt(2))
+	// 	require.Error(t, err)
+	// 	require.Nil(t, operation)
+	// })
+	//
+	// t.Run("RegisterProtocolOperation_InvalidChainID", func(t *testing.T) {
+	// 	require.Panics(t, func() {
+	// 		registry.RegisterProtocolOperation(AaveV3, SupplyAction, big.NewInt(-1), &GenericProtocolOperation{})
+	// 	})
+	// })
+	//
+	// t.Run("RegisterProtocolOperation_NilOperation", func(t *testing.T) {
+	// 	require.Panics(t, func() {
+	// 		registry.RegisterProtocolOperation(AaveV3, SupplyAction, big.NewInt(1), nil)
+	// 	})
+	// })
+}
+
 func TestProtocolRegistry(t *testing.T) {
 	registry := NewProtocolRegistry()
 	SetupProtocolOperations(getTestRPCURL(t), registry)

--- a/pkg/registry_test.go
+++ b/pkg/registry_test.go
@@ -35,7 +35,8 @@ func TestProtocolRegistry_Validate(t *testing.T) {
 		operation, err := registry.GetProtocolOperation(AaveV3, SupplyAction, big.NewInt(1))
 		require.NoError(t, err)
 
-		require.Nil(t, operation.Validate(common.HexToAddress(nativeDenomAddress)))
+		// native token not supported
+		require.Error(t, operation.Validate(common.HexToAddress(nativeDenomAddress)))
 	})
 
 	t.Run("ValidateAave_UnsupportedAsset", func(t *testing.T) {
@@ -49,7 +50,8 @@ func TestProtocolRegistry_Validate(t *testing.T) {
 		operation, err := registry.GetProtocolOperation(Lido, SubmitAction, big.NewInt(1))
 		require.NoError(t, err)
 
-		require.Nil(t, operation.Validate(common.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb49")))
+		require.Nil(t, operation.Validate(common.HexToAddress(nativeDenomAddress)))
+		require.Error(t, operation.Validate(common.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb49")))
 	})
 }
 

--- a/pkg/registry_test.go
+++ b/pkg/registry_test.go
@@ -31,6 +31,13 @@ func TestProtocolRegistry_Validate(t *testing.T) {
 		require.Nil(t, operation.Validate(common.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")))
 	})
 
+	t.Run("ValidateAave_NativeAsset", func(t *testing.T) {
+		operation, err := registry.GetProtocolOperation(AaveV3, SupplyAction, big.NewInt(1))
+		require.NoError(t, err)
+
+		require.Nil(t, operation.Validate(common.HexToAddress(nativeDenomAddress)))
+	})
+
 	t.Run("ValidateAave_UnsupportedAsset", func(t *testing.T) {
 		operation, err := registry.GetProtocolOperation(AaveV3, SupplyAction, big.NewInt(1))
 		require.NoError(t, err)
@@ -38,23 +45,12 @@ func TestProtocolRegistry_Validate(t *testing.T) {
 		require.Error(t, operation.Validate(common.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb49")))
 	})
 
-	// t.Run("GetProtocolOperation_NotExists", func(t *testing.T) {
-	// 	operation, err := registry.GetProtocolOperation(AaveV3, SupplyAction, big.NewInt(2))
-	// 	require.Error(t, err)
-	// 	require.Nil(t, operation)
-	// })
-	//
-	// t.Run("RegisterProtocolOperation_InvalidChainID", func(t *testing.T) {
-	// 	require.Panics(t, func() {
-	// 		registry.RegisterProtocolOperation(AaveV3, SupplyAction, big.NewInt(-1), &GenericProtocolOperation{})
-	// 	})
-	// })
-	//
-	// t.Run("RegisterProtocolOperation_NilOperation", func(t *testing.T) {
-	// 	require.Panics(t, func() {
-	// 		registry.RegisterProtocolOperation(AaveV3, SupplyAction, big.NewInt(1), nil)
-	// 	})
-	// })
+	t.Run("ValidateLido_NativeAsset", func(t *testing.T) {
+		operation, err := registry.GetProtocolOperation(Lido, SubmitAction, big.NewInt(1))
+		require.NoError(t, err)
+
+		require.Nil(t, operation.Validate(common.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb49")))
+	})
 }
 
 func TestProtocolRegistry(t *testing.T) {

--- a/pkg/rocket_pool.go
+++ b/pkg/rocket_pool.go
@@ -202,3 +202,11 @@ func (r *RocketPoolOperation) GetContractAddress(
 		return *r.rethContract.Address, nil
 	}
 }
+
+func (r *RocketPoolOperation) Validate(asset common.Address) error {
+	if IsNativeToken(asset) {
+		return nil
+	}
+
+	return fmt.Errorf("unsupported asset for rocket pool staking (%s)", asset.Hex())
+}

--- a/pkg/validate.go
+++ b/pkg/validate.go
@@ -10,7 +10,7 @@ import (
 const nativeDenomAddress = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 
 var tokenSupportedMap = map[int64]map[ProtocolName][]string{
-	1: map[ProtocolName][]string{
+	1: {
 		AaveV3: {
 			"0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0", // Wrapped Liquid Staked Ether
 			"0x2260fac5e5542a773aa44fbcfedf7c193bc2c599", // Wrapped BTC

--- a/pkg/validate.go
+++ b/pkg/validate.go
@@ -1,0 +1,45 @@
+package pkg
+
+import (
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// nativeDenomAddress native denom token address.
+const nativeDenomAddress = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+
+var tokenSupportedMap = map[int64]map[ProtocolName][]string{
+	1: map[ProtocolName][]string{
+		AaveV3: {
+			"0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0", // Wrapped Liquid Staked Ether
+			"0x2260fac5e5542a773aa44fbcfedf7c193bc2c599", // Wrapped BTC
+			"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", // USDC
+			"0xdac17f958d2ee523a2206206994597c13d831ec7", // Tether
+			"0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee", // Wrapped eETH
+			"0x514910771af9ca656af840dff83e8264ecf986ca", // ChainLink
+			"0xae78736cd615f374d3085123a210448e74fc6393", // RocketPool ETH
+			"0x6b175474e89094c44da98b954eedeac495271d0f", // DAI
+			"0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9", // Aave
+			"0x83f20f44975d03b1b09e64809b757c47f942beea", // savingsDAI
+			"0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2", // Maker
+			"0xBe9895146f7AF43049ca1c1AE358B0541Ea49704", // Coinbase Ether
+			"0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38", // osETH
+		},
+		SparkLend: {
+			"0x83f20f44975d03b1b09e64809b757c47f942beea", // savingsDAI
+			"0x2260fac5e5542a773aa44fbcfedf7c193bc2c599", // Wrapped BTC
+			"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", // USDC
+			"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", // WETH
+			"0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0", // wsETH
+			"0xae78736cd615f374d3085123a210448e74fc6393", // RocketPool ETH
+			"0xdac17f958d2ee523a2206206994597c13d831ec7", // Tether
+		},
+		Lido: {},
+	},
+}
+
+// IsNativeToken checks if the token is ETH
+func IsNativeToken(asset common.Address) bool {
+	return strings.ToLower(asset.Hex()) == nativeDenomAddress
+}


### PR DESCRIPTION
This PR adds a static map of all supported protocols. By default, the native token is accepted when no other
token address is provided.

> The tokens have been meticulously tested to be accepted by the protocols. Tokens that require isolated pools have not been included at this time