### PR TITLE
[BDHK-133] Add check for minimum amount that can be deposited in Rocketpool

### DIFF
--- a/pkg/rocket_pool.go
+++ b/pkg/rocket_pool.go
@@ -136,6 +136,9 @@ func NewRocketPool(rpcURL string, contractAddress ContractAddress, action Contra
 	}
 
 	depositSettingsContract, err := rp.MakeContract("rocketDAOProtocolSettingsDeposit", *settingsForDeposits, &bind.CallOpts{})
+	if err != nil {
+		return nil, err
+	}
 
 	parsedABI, err := abi.JSON(strings.NewReader(RocketPoolABI))
 	if err != nil {

--- a/pkg/rocketpool_test.go
+++ b/pkg/rocketpool_test.go
@@ -44,7 +44,7 @@ func TestRocketPoolOperation_GenerateCallData(t *testing.T) {
 			// 0xd0e30db0
 			expected: "0xd0e30db0",
 			args: []interface{}{
-				big.NewInt(1 * 1e6),
+				big.NewInt(1 * 1e18), // 1 ETH
 			},
 		},
 		{

--- a/pkg/rocketpool_test.go
+++ b/pkg/rocketpool_test.go
@@ -29,13 +29,42 @@ func TestRocketPoolOperation_GenerateCallData_SupportedAction(t *testing.T) {
 // TestRocketPoolOperation_GenerateCallData test rocket pool Stake UnStake calldata.
 func TestRocketPoolOperation_GenerateCallData(t *testing.T) {
 
+	amountInWei := new(big.Int)
+
+	// 10,0000 ETH in wei
+	amountInWei, ok := amountInWei.SetString("10000000000000000000000", 10)
+	require.True(t, ok)
+
 	tt := []struct {
 		name     string
 		action   ContractAction
 		method   ProtocolMethod
 		expected string
 		args     []interface{}
+		hasError bool
 	}{
+		{
+			name:   "Supply action ( failure, staked amount too low)",
+			action: NativeStake,
+			method: rocketPoolStake,
+			// cast calldata "deposit()"
+			// 0xd0e30db0
+			expected: "0xd0e30db0",
+			args: []interface{}{
+				big.NewInt(1 * 1e6),
+			},
+			hasError: true,
+		},
+		{
+			name:   "Supply action ( failure, staked amount too high)",
+			action: NativeStake,
+			method: rocketPoolStake,
+			// cast calldata "deposit()"
+			// 0xd0e30db0
+			expected: "0xd0e30db0",
+			args:     []interface{}{amountInWei},
+			hasError: true,
+		},
 		{
 			name:   "Supply action",
 			action: NativeStake,
@@ -74,8 +103,12 @@ func TestRocketPoolOperation_GenerateCallData(t *testing.T) {
 
 			calldata, err := rp.GenerateCalldata(v.args)
 
-			require.NoError(t, err)
+			if v.hasError {
+				require.Error(t, err)
+				return
+			}
 
+			require.NoError(t, err)
 			require.Equal(t, v.expected, calldata)
 		})
 	}


### PR DESCRIPTION
While running extra txs on tenderly this morning, I saw the contract making another call to `getMinimumDeposit()`, it 
makes sense for us to add this check too since we already check for the maximum amount too .

https://dashboard.tenderly.co/balloondogs/balloondogs/testnet/7be9ed86-85b5-4a89-aa32-180c2c55f61f/tx/mainnet/0x6eceef901250dff7965b38c912ef4cee2faac0fc36484428f5f150e6391d528b


https://dashboard.tenderly.co/balloondogs/balloondogs/testnet/7be9ed86-85b5-4a89-aa32-180c2c55f61f/tx/mainnet/0x4bd710d0fb543e4d02ad71df9abba54a8058fc43f256c339713c2a4110953d74?trace=0.1.0
