### PR TITLE
[BDHK-308] Validate amount only when unstaking

### DIFF
--- a/pkg/ankr.go
+++ b/pkg/ankr.go
@@ -119,10 +119,11 @@ func (l *AnkrOperation) Validate(ctx context.Context,
 	asset := nativeDenomAddress
 	if action == NativeUnStake {
 		asset = ankrEthER20Account.Hex()
-	}
 
-	if params.Amount.Cmp(big.NewInt(0)) <= 0 {
-		return errors.New("amount must be greater than zero")
+		// only validate amount during withdrawal
+		if params.Amount.Cmp(big.NewInt(0)) <= 0 {
+			return errors.New("amount must be greater than zero")
+		}
 	}
 
 	balance, err := l.GetBalance(ctx, l.chainID, params.Sender, common.HexToAddress(asset))

--- a/pkg/ankr_test.go
+++ b/pkg/ankr_test.go
@@ -49,14 +49,15 @@ func TestAnkr_Validate(t *testing.T) {
 	ankr, err := NewAnkrOperation(getTestClient(t), big.NewInt(1))
 	require.NoError(t, err)
 
-	t.Run("zero value staked", func(t *testing.T) {
+	t.Run("zero value unstaked", func(t *testing.T) {
 
-		err = ankr.Validate(context.Background(), big.NewInt(1), NativeStake, TransactionParams{
+		err = ankr.Validate(context.Background(), big.NewInt(1), NativeUnStake, TransactionParams{
 			Amount: big.NewInt(0),
 			Asset:  common.HexToAddress(nativeDenomAddress),
 			Sender: emptyTestWallet,
 		})
 
+		t.Log(err)
 		require.Error(t, err)
 	})
 

--- a/pkg/lido.go
+++ b/pkg/lido.go
@@ -123,16 +123,17 @@ func (l *LidoOperation) Validate(ctx context.Context,
 		return errors.New("action not supported")
 	}
 
-	if params.Amount.Cmp(big.NewInt(0)) <= 0 {
-		return errors.New("amount must be greater than zero")
-	}
-
 	asset := nativeDenomAddress
 	if action == NativeUnStake {
 		// will default to fetching the balance from the contract
 		// not implemented right now as it is recommended for holders to
 		// swap their stEth on DEXs or CEXs instead of waiting 3-10 days for lido withdrawal
 		asset = ""
+
+		// validate amount only during unstaking
+		if params.Amount.Cmp(big.NewInt(0)) <= 0 {
+			return errors.New("amount must be greater than zero")
+		}
 	}
 
 	balance, err := l.GetBalance(ctx, l.chainID, params.Sender, common.HexToAddress(asset))

--- a/pkg/lido_test.go
+++ b/pkg/lido_test.go
@@ -19,19 +19,6 @@ func getTestClient(t *testing.T) *ethclient.Client {
 
 func TestLido_Validate(t *testing.T) {
 
-	t.Run("zero value staked", func(t *testing.T) {
-
-		lido, err := NewLidoOperation(getTestClient(t), big.NewInt(1))
-		require.NoError(t, err)
-
-		err = lido.Validate(context.Background(), big.NewInt(1), NativeStake, TransactionParams{
-			Amount: big.NewInt(0),
-			Asset:  common.HexToAddress(nativeDenomAddress),
-		})
-
-		require.Error(t, err)
-	})
-
 	t.Run("unsupported chain", func(t *testing.T) {
 
 		lido, err := NewLidoOperation(getTestClient(t), big.NewInt(1))

--- a/pkg/registry.go
+++ b/pkg/registry.go
@@ -156,6 +156,7 @@ func (r *ProtocolRegistryImpl) setupProtocolOperations() error {
 	val, ok := r.chainConfigs["1"]
 	if !ok {
 		return errors.New("please provide ETH chain config")
+	}
 
 	client, err := ethclient.Dial(val.RPCURL)
 	if err != nil {

--- a/pkg/registry.go
+++ b/pkg/registry.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -152,7 +153,12 @@ func (r *ProtocolRegistryImpl) setupProtocolOperations() error {
 		return nil
 	}
 
-	client, err := ethclient.Dial("https://eth.public-rpc.com")
+	val, ok := r.chainConfigs["1"]
+	if !ok {
+		return errors.New("please ETH chain config")
+	}
+
+	client, err := ethclient.Dial(val.RPCURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/rocket_pool.go
+++ b/pkg/rocket_pool.go
@@ -163,7 +163,7 @@ func (r *RocketpoolOperation) withdraw(opts TransactionParams) (string, error) {
 	return HexPrefix + hex.EncodeToString(calldata), nil
 }
 
-func (r *RocketpoolOperation) deposit(opts TransactionParams) (string, error) {
+func (r *RocketpoolOperation) deposit(_ TransactionParams) (string, error) {
 
 	calldata, err := r.parsedABI.Pack("deposit")
 	if err != nil {
@@ -187,10 +187,6 @@ func (l *RocketpoolOperation) Validate(ctx context.Context,
 
 	if action != NativeStake && action != NativeUnStake {
 		return errors.New("action not supported")
-	}
-
-	if params.Amount.Cmp(big.NewInt(0)) <= 0 {
-		return errors.New("amount must be greater than zero")
 	}
 
 	amount := big.NewInt(0)
@@ -217,6 +213,11 @@ func (l *RocketpoolOperation) Validate(ctx context.Context,
 	if action == NativeUnStake {
 		// will default to fetching RETH balance
 		asset = ""
+
+		// validate amount only during unstaking
+		if params.Amount.Cmp(big.NewInt(0)) <= 0 {
+			return errors.New("amount must be greater than zero")
+		}
 	}
 
 	balance, err := l.GetBalance(ctx, l.chainID, params.Sender, common.HexToAddress(asset))


### PR DESCRIPTION
Validate amount only during unsticking for staking protocols. As the eth to be staked will usually be in `msg.value` not provided as ___data___ to the staking contract.


Also removed the previous hardcoding of the public npc endpoint, which leads to solver always failing as registry won't run 
checks against our testnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved validation logic for withdrawal actions across multiple operations, ensuring validation checks are context-sensitive.
  - Enhanced error handling for Ethereum client connections, prompting users for necessary configurations if missing.

- **Bug Fixes**
  - Removed unnecessary validation for deposit actions, allowing for more flexible handling of amounts in various operations.

- **Chores**
  - Streamlined method signatures by removing unused parameters in deposit methods to improve code clarity.
  - Renamed test cases for clarity and relevance to current functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->