### PR TITLE
[BDHK-311] Disable validation for LoanSupply use case 

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ The `Protocol` interface defines the methods that each protocol must implement:
 ```go
 type Protocol interface {
     GenerateCalldata(ctx context.Context, chainID *big.Int, action ContractAction, params TransactionParams) (string, error)
+    // Validate ideally should run checks for the balance
+    // Currently for LoanSuplly usecase, we do not run any checks
+    // because sometimes on the clientside, the usecase might be a multicall that swaps an asset
+    // for another one which is then supplied into the protocol hence validation will always fail
     Validate(ctx context.Context, chainID *big.Int, action ContractAction, params TransactionParams) error
     GetBalance(ctx context.Context, chainID *big.Int, account, asset common.Address) (*big.Int, error)
     GetSupportedAssets(ctx context.Context, chainID *big.Int) ([]common.Address, error)

--- a/pkg/aave.go
+++ b/pkg/aave.go
@@ -219,14 +219,13 @@ func (l *AaveOperation) Validate(ctx context.Context,
 		return errors.New("amount must be greater than zero")
 	}
 
-	asset := params.Asset
+	if action == LoanSupply {
+		return nil
+	}
 
-	if action == LoanWithdraw {
-		var err error
-		asset, err = l.getAToken(ctx, asset)
-		if err != nil {
-			return err
-		}
+	asset, err := l.getAToken(ctx, params.Asset)
+	if err != nil {
+		return err
 	}
 
 	balance, err := l.GetBalance(ctx, l.chainID, params.Sender, asset)

--- a/pkg/aave_test.go
+++ b/pkg/aave_test.go
@@ -130,6 +130,17 @@ func TestAave_Validate(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("user without balance balance cannot stake", func(t *testing.T) {
+
+		err = aave.Validate(context.Background(), big.NewInt(1), LoanSupply, TransactionParams{
+			Amount: big.NewInt(1),
+			Asset:  common.HexToAddress("0xdac17f958d2ee523a2206206994597c13d831ec7"),
+			Sender: common.HexToAddress(nativeDenomAddress),
+		})
+
+		require.NoError(t, err)
+	})
+
 	t.Run("user with usdt balance can supply", func(t *testing.T) {
 
 		err = aave.Validate(context.Background(), big.NewInt(1), LoanSupply, TransactionParams{

--- a/pkg/aave_test.go
+++ b/pkg/aave_test.go
@@ -130,17 +130,6 @@ func TestAave_Validate(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("user without usdt balance cannot supply", func(t *testing.T) {
-
-		err = aave.Validate(context.Background(), big.NewInt(1), LoanSupply, TransactionParams{
-			Amount: big.NewInt(100000),
-			Asset:  common.HexToAddress("0xae78736cd615f374d3085123a210448e74fc6393"),
-			Sender: common.HexToAddress(nativeDenomAddress),
-		})
-
-		require.Error(t, err)
-	})
-
 	t.Run("user with usdt balance can supply", func(t *testing.T) {
 
 		err = aave.Validate(context.Background(), big.NewInt(1), LoanSupply, TransactionParams{

--- a/pkg/compound.go
+++ b/pkg/compound.go
@@ -155,6 +155,10 @@ func (l *CompoundOperation) Validate(ctx context.Context,
 		return errors.New("action not supported")
 	}
 
+	if action == LoanSupply {
+		return nil
+	}
+
 	if params.Amount.Cmp(big.NewInt(0)) <= 0 {
 		return errors.New("amount must be greater than zero")
 	}


### PR DESCRIPTION
As agreed on, this PR removes the checks for `LoanSupply` because of unique use cases especially from the solver
where the asset to be validated is part of a larger calldata that includes what this registry (will generate) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added clarifications to the `README.md` regarding the `Validate` method's functionality and limitations in the context of `LoanSupply`.

- **New Features**
  - Enhanced the `Validate` method in `AaveOperation` to streamline control flow for `LoanSupply` actions, reducing complexity.
  - Improved the `Validate` method in `CompoundOperation` to allow `LoanSupply` actions to bypass certain validation checks.

- **Tests**
  - Updated the `TestAave_Validate` test case to reflect changes in user interactions, verifying that users can stake assets without a USDT balance. 
  - Removed a test case for users without a USDT balance, focusing on more relevant scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->