### PR TITLE
fix: polygon supported token only

### DIFF
--- a/tokens/137.json
+++ b/tokens/137.json
@@ -7,6 +7,18 @@
       "decimals": 18
     },
     {
+      "token_address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+      "name": "Wrapped Matic",
+      "symbol": "WMATIC",
+      "decimals": 18
+    },
+    {
+      "token_address": "0x172370d5Cd63279eFa6d502DAB29171933a610AF",
+      "name": "Curve Finance token",
+      "symbol": "CRV",
+      "decimals": 18
+    },
+    {
       "token_address": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
       "name": "Dai Token",
       "symbol": "DAI",
@@ -52,12 +64,6 @@
       "token_address": "0xD6DF932A45C0f255f85145f286eA0b292B21C90B",
       "name": "Aave",
       "symbol": "AAVE",
-      "decimals": 18
-    },
-    {
-      "token_address": "0x172370d5Cd63279eFa6d502DAB29171933a610AF",
-      "name": "Curve Finance token",
-      "symbol": "CRV",
       "decimals": 18
     },
     {

--- a/tokens/137.json
+++ b/tokens/137.json
@@ -13,12 +13,6 @@
       "decimals": 18
     },
     {
-      "token_address": "0x172370d5Cd63279eFa6d502DAB29171933a610AF",
-      "name": "Curve Finance token",
-      "symbol": "CRV",
-      "decimals": 18
-    },
-    {
       "token_address": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
       "name": "Dai Token",
       "symbol": "DAI",


### PR DESCRIPTION
* Its important to include token that is supported by the current price feeder service
* wrapped is an important listing for Native <-> any operation (ERC20 as a base)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced "Wrapped Matic" (WMATIC) token with its details for enhanced asset management.
  
- **Bug Fixes**
	- Removed the outdated "Curve Finance token" (CRV) entry to streamline the token list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->