### PR TITLE
[BDHK-365] GetBalance should return the user collateral for each asset instead

### DIFF
--- a/pkg/compound.go
+++ b/pkg/compound.go
@@ -345,6 +345,10 @@ func (l *CompoundOperation) GetBalance(ctx context.Context,
 
 	var address common.Address
 
+	if !l.IsSupportedAsset(ctx, chainID, asset) {
+		return address, nil, errors.New("unsupported asset. cannot fetch it's balance")
+	}
+
 	if chainID.Int64() != 1 {
 		return address, nil, ErrChainUnsupported
 	}
@@ -363,7 +367,8 @@ func (l *CompoundOperation) GetBalance(ctx context.Context,
 	}
 
 	balance := new(big.Int)
-	err = l.parsedABI.UnpackIntoInterface(&balance, "userCollateral", result)
+	res := new(big.Int)
+	err = l.parsedABI.UnpackIntoInterface(&[]interface{}{&balance, &res}, "userCollateral", result)
 	return l.contract, balance, err
 }
 

--- a/pkg/compound.go
+++ b/pkg/compound.go
@@ -15,36 +15,60 @@ import (
 )
 
 const compoundv3ABI = `
- [
-   {
-     "name": "withdraw",
-     "type": "function",
-     "inputs": [
-       {
-         "type": "address"
-       },
-       {
-         "type": "uint256"
-       }
-     ]
-   },
-   {
-     "name": "supply",
-     "type": "function",
-     "inputs": [
-       {
-         "type": "address"
-       },
-       {
-         "type": "uint256"
-       }
-     ]
-   }
- ]
- 	`
-
-const compoundPoolABI = `
 [
+  {
+    "name": "withdraw",
+    "type": "function",
+    "inputs": [
+      {
+        "type": "address"
+      },
+      {
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "name": "supply",
+    "type": "function",
+    "inputs": [
+      {
+        "type": "address"
+      },
+      {
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "userCollateral",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "balance",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "_reserved",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
   {
     "inputs": [],
     "name": "numAssets",
@@ -113,7 +137,7 @@ const compoundPoolABI = `
     "type": "function"
   }
 ]
-	`
+`
 
 const (
 	CompoundV3USDCPool = "0xc3d688b66703497daa19211eedff47f25384cdc3"
@@ -142,7 +166,7 @@ type CompoundOperation struct {
 	contract  common.Address
 	chainID   *big.Int
 	version   string
-	erc20ABI  abi.ABI
+
 	// assets that are supported in this pool
 	supportedAssets []common.Address
 
@@ -157,12 +181,7 @@ func NewCompoundOperation(client *ethclient.Client, chainID *big.Int,
 		return nil, err
 	}
 
-	erc20ABI, err := abi.JSON(strings.NewReader(erc20BalanceOfABI))
-	if err != nil {
-		return nil, err
-	}
-
-	supportedAssets, err := getSupportedAssets(client, marketPool)
+	supportedAssets, err := getSupportedAssets(parsedABI, client, marketPool)
 	if err != nil {
 		return nil, err
 	}
@@ -178,17 +197,11 @@ func NewCompoundOperation(client *ethclient.Client, chainID *big.Int,
 		chainID:         chainID,
 		version:         "3",
 		client:          client,
-		erc20ABI:        erc20ABI,
 	}, nil
 }
 
-func getSupportedAssets(client *ethclient.Client, marketPool common.Address) (
-	[]common.Address, error) {
-
-	parsedPoolABI, err := abi.JSON(strings.NewReader(compoundPoolABI))
-	if err != nil {
-		return nil, err
-	}
+func getSupportedAssets(parsedPoolABI abi.ABI,
+	client *ethclient.Client, marketPool common.Address) ([]common.Address, error) {
 
 	numAssetsCallData, err := parsedPoolABI.Pack("numAssets")
 	if err != nil {
@@ -328,7 +341,7 @@ func (l *CompoundOperation) Validate(ctx context.Context,
 // GetBalance retrieves the balance for a specified account and asset
 func (l *CompoundOperation) GetBalance(ctx context.Context,
 	chainID *big.Int,
-	account, _ common.Address) (common.Address, *big.Int, error) {
+	account, asset common.Address) (common.Address, *big.Int, error) {
 
 	var address common.Address
 
@@ -336,7 +349,7 @@ func (l *CompoundOperation) GetBalance(ctx context.Context,
 		return address, nil, ErrChainUnsupported
 	}
 
-	callData, err := l.erc20ABI.Pack("balanceOf", account)
+	callData, err := l.parsedABI.Pack("userCollateral", account, asset)
 	if err != nil {
 		return address, nil, err
 	}
@@ -350,7 +363,7 @@ func (l *CompoundOperation) GetBalance(ctx context.Context,
 	}
 
 	balance := new(big.Int)
-	err = l.erc20ABI.UnpackIntoInterface(&balance, "balanceOf", result)
+	err = l.parsedABI.UnpackIntoInterface(&balance, "userCollateral", result)
 	return l.contract, balance, err
 }
 

--- a/pkg/compound_test.go
+++ b/pkg/compound_test.go
@@ -6,8 +6,10 @@ package pkg
 import (
 	"context"
 	"math/big"
+	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -103,12 +105,15 @@ func TestCompound_GetSupportedAssets(t *testing.T) {
 
 	client := getTestClient(t, ChainETH)
 
-	assets, err := getSupportedAssets(client, common.HexToAddress(CompoundV3ETHPool))
+	parsedABI, err := abi.JSON(strings.NewReader(compoundv3ABI))
+	require.NoError(t, err)
+
+	assets, err := getSupportedAssets(parsedABI, client, common.HexToAddress(CompoundV3ETHPool))
 	require.NoError(t, err)
 
 	require.NotEmpty(t, assets)
 
-	assets, err = getSupportedAssets(client, common.HexToAddress(CompoundV3USDCPool))
+	assets, err = getSupportedAssets(parsedABI, client, common.HexToAddress(CompoundV3USDCPool))
 	require.NoError(t, err)
 
 	require.NotEmpty(t, assets)

--- a/pkg/compound_test.go
+++ b/pkg/compound_test.go
@@ -128,13 +128,24 @@ func TestCompound_GetBalance(t *testing.T) {
 
 	require.NoError(t, err)
 
-	_, bal, err := compoundImpl.GetBalance(context.Background(), big.NewInt(1),
-		common.HexToAddress("0x94fa8efDD58e1721ad8Bf5D4001060e0E1C4d58e"),
-		common.HexToAddress(""))
+	t.Run("unsupported asset", func(t *testing.T) {
 
-	require.NoError(t, err)
-	require.NotNil(t, bal)
+		_, _, err := compoundImpl.GetBalance(context.Background(), big.NewInt(1),
+			common.HexToAddress("0x94fa8efDD58e1721ad8Bf5D4001060e0E1C4d58e"),
+			common.HexToAddress(""))
 
+		require.Error(t, err)
+	})
+
+	t.Run("supported WETH asset", func(t *testing.T) {
+
+		_, bal, err := compoundImpl.GetBalance(context.Background(), big.NewInt(1),
+			common.HexToAddress("0x94fa8efDD58e1721ad8Bf5D4001060e0E1C4d58e"),
+			common.HexToAddress("0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"))
+
+		require.NoError(t, err)
+		require.NotNil(t, bal)
+	})
 }
 
 func TestCompoundV3_Validate_ETH_Market(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `userCollateral` function to support collateral queries.
	- Enhanced ABI management for improved contract interaction.

- **Bug Fixes**
	- Updated the `GetBalance` method to utilize the new `userCollateral` function.

- **Tests**
	- Refined existing test cases to incorporate ABI parsing for asset retrieval and improved error handling for asset scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->