### PR TITLE
Add protocol types to supported chain list

### DIFF
--- a/tokens/1.json
+++ b/tokens/1.json
@@ -106,6 +106,7 @@
   "protocols": [
     {
       "address": "0x84db6ee82b7cf3b47e8f19270abde5718b936670",
+      "type": "staking",
       "name": "Ankr",
       "source": true,
       "destination": true,
@@ -116,6 +117,7 @@
     {
       "address": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
       "name": "Lido",
+      "type": "staking",
       "source": false,
       "destination": true,
       "tokens": [
@@ -125,6 +127,7 @@
     {
       "address": "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46",
       "name": "Rocketpool",
+      "type": "staking",
       "source": true,
       "destination": true,
       "tokens": [
@@ -135,6 +138,7 @@
     {
       "address": "0xC13e21B648A5Ee794902342038FF3aDAB66BE987",
       "name": "SparkLend",
+      "type": "lending",
       "source": true,
       "destination": true,
       "tokens": [
@@ -150,6 +154,7 @@
     {
       "address": "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
       "name": "Compound ETH Pool",
+      "type": "lending",
       "source": true,
       "destination": true,
       "tokens": [
@@ -164,6 +169,7 @@
     {
       "address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
       "name": "Compound USDC Pool",
+      "type": "lending",
       "source": true,
       "destination": true,
       "tokens": [
@@ -178,6 +184,7 @@
     {
       "address": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
       "name": "AaveV3",
+      "type": "lending",
       "source": true,
       "destination": true,
       "tokens": [

--- a/tokens/137.json
+++ b/tokens/137.json
@@ -77,6 +77,7 @@
     {
       "address": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
       "name": "AaveV3",
+      "type": "lending",
       "source": true,
       "destination": true,
       "tokens": [

--- a/tokens/56.json
+++ b/tokens/56.json
@@ -59,6 +59,7 @@
     {
       "address": "0x6807dc923806fE8Fd134338EABCA509979a7e0cB",
       "name": "AaveV3",
+      "type": "lending",
       "source": true,
       "destination": true,
       "tokens": [
@@ -72,6 +73,7 @@
     {
       "address": "0xf9278C7c4AEfAC4dDfd0D496f7a1C39cA6BCA6d4",
       "name": "AvalonFinance",
+      "type": "lending",
       "source": true,
       "destination": true,
       "tokens": [
@@ -83,6 +85,7 @@
     {
       "address": "0x1adB950d8bB3dA4bE104211D5AB038628e477fE6",
       "name": "ListaDAO",
+      "type": "staking",
       "source": false,
       "destination": true,
       "tokens": [

--- a/tokens/token.go
+++ b/tokens/token.go
@@ -15,11 +15,12 @@ type Token struct {
 
 // Protocol represents a protocol with its properties
 type Protocol struct {
-	Address     string   `json:"address"`
-	Name        string   `json:"name"`
-	Source      bool     `json:"source"`
-	Destination bool     `json:"destination"`
-	Tokens      []string `json:"tokens"`
+	Address     string   `json:"address,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Source      bool     `json:"source,omitempty"`
+	Destination bool     `json:"destination,omitempty"`
+	Tokens      []string `json:"tokens,omitempty"`
+	Type        string   `json:"type,omitempty"`
 }
 
 // Data represents the entire structure of the JSON file


### PR DESCRIPTION
This is useful for the frontend team else they will have to maintain their own list of what is a staking protocol and lending 
among others

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `type` property for protocols, categorizing them into "staking" and "lending".
	- Enhanced metadata for protocols including "Ankr", "Lido", "Rocketpool", "SparkLend", "Compound ETH Pool", "Compound USDC Pool", "AaveV3", "AvalonFinance", and "ListaDAO".

- **Bug Fixes**
	- Improved clarity and consistency in protocol classifications across multiple JSON files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->